### PR TITLE
Added guards for rename migration

### DIFF
--- a/db/migrate/20181012193645_rename.rb
+++ b/db/migrate/20181012193645_rename.rb
@@ -1,5 +1,7 @@
 class Rename < ActiveRecord::Migration[5.2]
   def change
-    rename_column :items, :name, :title
+    if column_exists?(:items, :name)
+      rename_column :items, :name, :title
+    end
   end
 end

--- a/db/migrate/20181012210514_rename_checked_out_to_available.rb
+++ b/db/migrate/20181012210514_rename_checked_out_to_available.rb
@@ -1,5 +1,7 @@
 class RenameCheckedOutToAvailable < ActiveRecord::Migration[5.2]
   def change
-    rename_column :items, :checked_out, :available
+    if column_exists?(:items, :checked_out)
+      rename_column :items, :checked_out, :available
+    end
   end
 end


### PR DESCRIPTION
Due to issues on my part, a rename migration file had to be remade (was included in last merge to Master). I believe this only affected my build, but I added guards to the other rename as well to make sure migrations worked smoothly.